### PR TITLE
Fixes bug when ip2long is called in a 64 bits system

### DIFF
--- a/models/Favorite.php
+++ b/models/Favorite.php
@@ -82,7 +82,14 @@ class Favorite extends ActiveRecord
                     ActiveRecord::EVENT_BEFORE_INSERT => 'created_ip'
                 ],
                 'value' => function ($event) {
-                    return ip2long(Yii::$app->request->getUserIP());
+                    $ip = ip2long(Yii::$app->request->getUserIP());
+                    if (PHP_INT_SIZE == 8) {
+                        if ($ip > 0x7FFFFFFF) {
+                            $ip -= 0x100000000;
+                        }
+                    }
+
+                    return $ip;
                 }
             ],
             [

--- a/models/Favorite.php
+++ b/models/Favorite.php
@@ -83,10 +83,8 @@ class Favorite extends ActiveRecord
                 ],
                 'value' => function ($event) {
                     $ip = ip2long(Yii::$app->request->getUserIP());
-                    if (PHP_INT_SIZE == 8) {
-                        if ($ip > 0x7FFFFFFF) {
-                            $ip -= 0x100000000;
-                        }
+                    if ($ip > 0x7FFFFFFF) {
+                        $ip -= 0x100000000;
                     }
 
                     return $ip;


### PR DESCRIPTION
Some DB (like postgresql) doesn't have unsigned int type, so, this function allow to store the right value.